### PR TITLE
Don't depend on positioned-io in rc-zip

### DIFF
--- a/crates/rc-zip/Cargo.toml
+++ b/crates/rc-zip/Cargo.toml
@@ -28,5 +28,5 @@ chardetng = "0.1.17"
 
 [features]
 default = ["sync", "file"]
-sync = ["positioned-io", "libflate"]
-file = []
+sync = ["libflate"]
+file = ["positioned-io"]

--- a/crates/rc-zip/src/prelude.rs
+++ b/crates/rc-zip/src/prelude.rs
@@ -2,5 +2,3 @@
 
 #[cfg(feature = "sync")]
 pub use crate::reader::sync::{ReadZip, ReadZipWithSize};
-#[cfg(feature = "sync")]
-pub use positioned_io::ReadAt;

--- a/crates/rc-zip/src/reader/sync/read_zip.rs
+++ b/crates/rc-zip/src/reader/sync/read_zip.rs
@@ -73,6 +73,14 @@ impl ReadZip for &[u8] {
     }
 }
 
+impl ReadZip for Vec<u8> {
+    type File = Self;
+
+    fn read_zip(&self) -> Result<SyncArchive<'_, Self::File>, Error> {
+        self.read_zip_with_size(self.len() as u64)
+    }
+}
+
 pub struct SyncArchive<'a, F>
 where
     F: HasCursor,
@@ -169,6 +177,16 @@ pub trait HasCursor {
 }
 
 impl HasCursor for &[u8] {
+    type Cursor<'a> = &'a [u8]
+    where
+        Self: 'a;
+
+    fn cursor_at(&self, offset: u64) -> Self::Cursor<'_> {
+        &self[offset.try_into().unwrap()..]
+    }
+}
+
+impl HasCursor for Vec<u8> {
     type Cursor<'a> = &'a [u8]
     where
         Self: 'a;

--- a/crates/rc-zip/src/tests.rs
+++ b/crates/rc-zip/src/tests.rs
@@ -164,7 +164,8 @@ fn real_world_files() {
     for case in test_cases() {
         let case_name = case.name();
         let case_bytes = case.bytes();
-        let archive = case_bytes.read_zip();
+        let slice = case_bytes.as_slice();
+        let archive = slice.read_zip();
 
         if let Some(expected) = case.error {
             let actual = archive.expect_err("should have errored");

--- a/crates/rc-zip/src/tests.rs
+++ b/crates/rc-zip/src/tests.rs
@@ -164,8 +164,7 @@ fn real_world_files() {
     for case in test_cases() {
         let case_name = case.name();
         let case_bytes = case.bytes();
-        let slice = case_bytes.as_slice();
-        let archive = slice.read_zip();
+        let archive = case_bytes.read_zip();
 
         if let Some(expected) = case.error {
             let actual = archive.expect_err("should have errored");


### PR DESCRIPTION
Closes #16

Introduces `HasCursor` and implements it on `Vec<u8>` and `&[u8]` (also `std::fs::File` if both the "sync" and "file" features are enabled).

This should make it usable from wasm.