### PR TITLE
refactor: manually implement `thiserror` code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,6 @@ dependencies = [
  "oval",
  "ownable",
  "temp-dir",
- "thiserror",
  "tracing",
  "tracing-subscriber",
  "winnow",
@@ -756,26 +755,6 @@ name = "temp-dir"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
-
-[[package]]
-name = "thiserror"
-version = "2.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "thread_local"

--- a/rc-zip/Cargo.toml
+++ b/rc-zip/Cargo.toml
@@ -22,7 +22,6 @@ chrono.workspace = true
 encoding_rs.workspace = true
 tracing.workspace = true
 oem_cp.workspace = true
-thiserror.workspace = true
 chardetng.workspace = true
 crc32fast.workspace = true
 miniz_oxide = { workspace = true, optional = true }

--- a/rc-zip/src/encoding.rs
+++ b/rc-zip/src/encoding.rs
@@ -40,21 +40,18 @@ impl fmt::Display for Encoding {
 }
 
 /// Errors encountered while converting text to UTF-8.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum DecodingError {
     /// Text claimed to be UTF-8, but wasn't (as far as we can tell).
-    #[error("invalid utf-8: {0}")]
     Utf8Error(std::str::Utf8Error),
 
     /// Text is too large to be converted.
     ///
     /// In practice, this happens if the text's length is larger than
     /// [usize::MAX], which seems unlikely.
-    #[error("text too large to be converted")]
     StringTooLarge,
 
     /// Text is not valid in the given encoding.
-    #[error("encoding error: {0}")]
     EncodingError(&'static str),
 }
 
@@ -63,6 +60,18 @@ impl From<std::str::Utf8Error> for DecodingError {
         DecodingError::Utf8Error(e)
     }
 }
+
+impl fmt::Display for DecodingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Utf8Error(utf8) => write!(f, "invalid utf-8: {utf8}"),
+            Self::StringTooLarge => f.write_str("text too large to be converted"),
+            Self::EncodingError(enc) => write!(f, "encoding error: {enc}"),
+        }
+    }
+}
+
+impl std::error::Error for DecodingError {}
 
 impl Encoding {
     pub(crate) fn decode(&self, i: &[u8]) -> Result<String, DecodingError> {

--- a/rc-zip/src/error.rs
+++ b/rc-zip/src/error.rs
@@ -1,5 +1,7 @@
 //! All error types used in this crate
 
+use std::{error, fmt, io};
+
 use crate::parse::Method;
 
 use super::encoding;
@@ -8,26 +10,21 @@ use super::encoding;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Any zip-related error, from invalid archives to encoding problems.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
     /// Not a valid zip file, or a variant that is unsupported.
-    #[error("format: {0}")]
-    Format(#[from] FormatError),
+    Format(FormatError),
 
     /// Something is not supported by this crate
-    #[error("unsupported: {0}")]
-    Unsupported(#[from] UnsupportedError),
+    Unsupported(UnsupportedError),
 
     /// Invalid UTF-8, Shift-JIS, or any problem encountered while decoding text in general.
-    #[error("encoding: {0:?}")]
-    Encoding(#[from] encoding::DecodingError),
+    Encoding(encoding::DecodingError),
 
     /// I/O-related error
-    #[error("io: {0}")]
-    IO(#[from] std::io::Error),
+    IO(io::Error),
 
     /// Decompression-related error
-    #[error("{method:?} decompression error: {msg}")]
     Decompression {
         /// The compression method that failed
         method: Method,
@@ -36,7 +33,6 @@ pub enum Error {
     },
 
     /// Could not read as a zip because size could not be determined
-    #[error("size must be known to open zip file")]
     UnknownSize,
 }
 
@@ -52,19 +48,66 @@ impl Error {
     }
 }
 
+impl From<FormatError> for Error {
+    fn from(fmt_err: FormatError) -> Self {
+        Self::Format(fmt_err)
+    }
+}
+
+impl From<UnsupportedError> for Error {
+    fn from(unsupported: UnsupportedError) -> Self {
+        Self::Unsupported(unsupported)
+    }
+}
+
+impl From<encoding::DecodingError> for Error {
+    fn from(enc: encoding::DecodingError) -> Self {
+        Self::Encoding(enc)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(io: io::Error) -> Self {
+        Self::IO(io)
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(e: Error) -> Self {
+        match e {
+            Error::IO(e) => e,
+            e => io::Error::other(e),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Format(format) => write!(f, "format: {format}"),
+            Self::Unsupported(unsupported) => write!(f, "unsupported: {unsupported}"),
+            Self::Encoding(enc) => write!(f, "encoding: {enc:?}"),
+            Self::IO(io) => write!(f, "io: {io}"),
+            Self::Decompression { method, msg } => {
+                write!(f, "{method:?} decompression error: {msg}")
+            }
+            Self::UnknownSize => f.write_str("size must be known to open zip file"),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
 /// Some part of the zip format is not supported by this crate.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum UnsupportedError {
     /// The compression method is not supported.
-    #[error("compression method not supported: {0:?}")]
     MethodNotSupported(Method),
 
     /// The compression method is supported, but not enabled in this build.
-    #[error("compression method supported, but not enabled in this build: {0:?}")]
     MethodNotEnabled(Method),
 
     /// The zip file uses a version of LZMA that is not supported.
-    #[error("only LZMA2.0 is supported, found LZMA{minor}.{major}")]
     LzmaVersionUnsupported {
         /// major version read from LZMA properties header, cf. appnote 5.8.8
         major: u8,
@@ -73,7 +116,6 @@ pub enum UnsupportedError {
     },
 
     /// The LZMA properties header is not the expected size.
-    #[error("LZMA properties header wrong size: expected {expected} bytes, got {actual} bytes")]
     LzmaPropertiesHeaderWrongSize {
         /// expected size in bytes
         expected: u16,
@@ -82,26 +124,43 @@ pub enum UnsupportedError {
     },
 }
 
+impl fmt::Display for UnsupportedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MethodNotSupported(m) => write!(f, "compression method not supported: {m:?}"),
+            Self::MethodNotEnabled(m) => write!(
+                f,
+                "compression method supported, but not enabled in this build: {m:?}"
+            ),
+            Self::LzmaVersionUnsupported { major, minor } => {
+                write!(f, "only LZMA2.0 is supported, found LZMA{major}.{minor}")
+            }
+            Self::LzmaPropertiesHeaderWrongSize { expected, actual } => {
+                write!(f, "LZMA properties header wrong size: expected {expected} bytes, got {actual} bytes")
+            }
+        }
+    }
+}
+
+impl error::Error for UnsupportedError {}
+
 /// Specific zip format errors, mostly due to invalid zip archives but that could also stem from
 /// implementation shortcomings.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum FormatError {
     /// The end of central directory record was not found.
     ///
     /// This usually indicates that the file being read is not a zip archive.
-    #[error("end of central directory record not found")]
     DirectoryEndSignatureNotFound,
 
     /// The zip64 end of central directory record could not be parsed.
     ///
     /// This is only returned when a zip64 end of central directory *locator* was found,
     /// so the archive should be zip64, but isn't.
-    #[error("zip64 end of central directory record not found")]
     Directory64EndRecordInvalid,
 
     /// Corrupted/partial zip file: the offset we found for the central directory
     /// points outside of the current file.
-    #[error("directory offset points outside of file")]
     DirectoryOffsetPointsOutsideFile,
 
     /// The central record is corrupted somewhat.
@@ -109,7 +168,6 @@ pub enum FormatError {
     /// This can happen when the end of central directory record advertises
     /// a certain number of files, but we weren't able to read the same number of central directory
     /// headers.
-    #[error("invalid central record: expected to read {expected} files, got {actual}")]
     InvalidCentralRecord {
         /// expected number of files
         expected: u16,
@@ -120,20 +178,17 @@ pub enum FormatError {
     /// An extra field (that we support) was not decoded correctly.
     ///
     /// This can indicate an invalid zip archive, or an implementation error in this crate.
-    #[error("could not decode extra field")]
     InvalidExtraField,
 
     /// The header offset of an entry is invalid.
     ///
     /// This can indicate an invalid zip archive, or an invalid user-provided global offset
-    #[error("invalid header offset")]
     InvalidHeaderOffset,
 
     /// End of central directory record claims an impossible number of files.
     ///
     /// Each entry takes a minimum amount of size, so if the overall archive size is smaller than
     /// claimed_records_count * minimum_entry_size, we know it's not a valid zip file.
-    #[error("impossible number of files: claims to have {claimed_records_count}, but zip size is {zip_size}")]
     ImpossibleNumberOfFiles {
         /// number of files claimed in the end of central directory record
         claimed_records_count: u64,
@@ -142,15 +197,12 @@ pub enum FormatError {
     },
 
     /// The local file header (before the file data) could not be parsed correctly.
-    #[error("invalid local file header")]
     InvalidLocalHeader,
 
     /// The data descriptor (after the file data) could not be parsed correctly.
-    #[error("invalid data descriptor")]
     InvalidDataDescriptor,
 
     /// The uncompressed size didn't match
-    #[error("uncompressed size didn't match: expected {expected}, got {actual}")]
     WrongSize {
         /// expected size in bytes (from the local header, data descriptor, etc.)
         expected: u64,
@@ -159,7 +211,6 @@ pub enum FormatError {
     },
 
     /// The CRC-32 checksum didn't match.
-    #[error("checksum didn't match: expected {expected:x?}, got {actual:x?}")]
     WrongChecksum {
         /// expected checksum (from the data descriptor, etc.)
         expected: u32,
@@ -168,11 +219,51 @@ pub enum FormatError {
     },
 }
 
-impl From<Error> for std::io::Error {
-    fn from(e: Error) -> Self {
-        match e {
-            Error::IO(e) => e,
-            e => std::io::Error::other(e),
+impl fmt::Display for FormatError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DirectoryEndSignatureNotFound => {
+                f.write_str("end of central directory record not found")
+            }
+            Self::Directory64EndRecordInvalid => {
+                f.write_str("zip64 end of central directory record not found")
+            }
+            Self::DirectoryOffsetPointsOutsideFile => {
+                f.write_str("directory offset points outside of file")
+            }
+            Self::InvalidCentralRecord { expected, actual } => {
+                write!(
+                    f,
+                    "invalid central record: expected to read {expected} files, got {actual}"
+                )
+            }
+            Self::InvalidExtraField => f.write_str("could not decode extra field"),
+            Self::InvalidHeaderOffset => f.write_str("invalid header offset"),
+            Self::ImpossibleNumberOfFiles {
+                claimed_records_count,
+                zip_size,
+            } => {
+                write!(
+                    f,
+                    "impossible number of files: claims to have {claimed_records_count}, but zip size is {zip_size}"
+                )
+            }
+            Self::InvalidLocalHeader => f.write_str("invalid local file header"),
+            Self::InvalidDataDescriptor => f.write_str("invalid data descriptor"),
+            Self::WrongSize { expected, actual } => {
+                write!(
+                    f,
+                    "uncompressed size didn't match: expected {expected}, got {actual}"
+                )
+            }
+            Self::WrongChecksum { expected, actual } => {
+                write!(
+                    f,
+                    "checksum didn't match: expected {expected:x?}, got {actual:x?}"
+                )
+            }
         }
     }
 }
+
+impl error::Error for FormatError {}


### PR DESCRIPTION
drops another dependency that uses `syn`. overall there isn't much additional boilerplate to get the same effect. a lot of the loc comes from `rustfmt` spreading the `write!()`s over a bunch of lines

`cargo semver-checks` is happy, so all of the same traits are implemented at least