### PR TITLE
fix: bounds check before seeking from archive fsm

### DIFF
--- a/rc-zip-sync/src/read_zip.rs
+++ b/rc-zip-sync/src/read_zip.rs
@@ -33,6 +33,25 @@ pub trait ReadZip {
     fn read_zip(&self) -> Result<ArchiveHandle<'_, Self::File>, Error>;
 }
 
+struct CursorState<'a, F: HasCursor + 'a> {
+    cursor: <F as HasCursor>::Cursor<'a>,
+    offset: u64,
+}
+
+impl<'a, F: HasCursor + 'a> CursorState<'a, F> {
+    /// Constructs a cursor only _after_ doing a bounds check with `offset` and `size`
+    fn try_new(has_cursor: &'a F, offset: u64, size: u64) -> Result<Self, Error> {
+        if offset > size {
+            return Err(std::io::Error::other(format!(
+                "archive tried reading beyond zip archive end. {offset} goes beyond {size}"
+            ))
+            .into());
+        }
+        let cursor = has_cursor.cursor_at(offset);
+        Ok(Self { cursor, offset })
+    }
+}
+
 impl<F> ReadZipWithSize for F
 where
     F: HasCursor,
@@ -40,10 +59,6 @@ where
     type File = F;
 
     fn read_zip_with_size(&self, size: u64) -> Result<ArchiveHandle<'_, F>, Error> {
-        struct CursorState<'a, F: HasCursor + 'a> {
-            cursor: <F as HasCursor>::Cursor<'a>,
-            offset: u64,
-        }
         let mut cstate: Option<CursorState<'_, F>> = None;
 
         let mut fsm = ArchiveFsm::new(size);
@@ -52,21 +67,16 @@ where
                 trace!(%offset, "read_zip_with_size: wants_read, space len = {}", fsm.space().len());
 
                 let mut cstate_next = match cstate.take() {
+                    // all good, re-using
+                    Some(cstate) if cstate.offset == offset => cstate,
                     Some(cstate) => {
-                        if cstate.offset == offset {
-                            // all good, re-using
-                            cstate
-                        } else {
-                            CursorState {
-                                cursor: self.cursor_at(offset),
-                                offset,
-                            }
-                        }
+                        trace!(%offset, %cstate.offset, "read_zip_with_size: making new cursor (had wrong offset)");
+                        CursorState::try_new(self, offset, size)?
                     }
-                    None => CursorState {
-                        cursor: self.cursor_at(offset),
-                        offset,
-                    },
+                    None => {
+                        trace!(%offset, "read_zip_with_size: making new cursor (had none)");
+                        CursorState::try_new(self, offset, size)?
+                    }
                 };
 
                 match cstate_next.cursor.read(fsm.space()) {

--- a/rc-zip-sync/tests/regression.rs
+++ b/rc-zip-sync/tests/regression.rs
@@ -1,0 +1,15 @@
+#[test]
+fn archive_oob_errors_gracefully() {
+    let bad_archive = [
+        0x50u8, 0x4b, 0x6, 0x7, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x50, 0x4b, 0x5,
+        0x6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    let Err(err) = rc_zip_sync::ReadZip::read_zip(&bad_archive.as_slice()) else {
+        // NOTE(cosmic): `.unwrap_err()` requires `ArchiveHandle` to impl `Debug`, but it doesn't
+        panic!("expected error, but parsed a valid archive");
+    };
+    assert_eq!(
+        err.to_string(),
+        "io: archive tried reading beyond zip archive end. 65536 goes beyond 42"
+    );
+}

--- a/rc-zip-tokio/tests/regression.rs
+++ b/rc-zip-tokio/tests/regression.rs
@@ -1,0 +1,15 @@
+#[tokio::test]
+async fn archive_oob_errors_gracefully() {
+    let bad_archive = [
+        0x50u8, 0x4b, 0x6, 0x7, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x50, 0x4b, 0x5,
+        0x6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    let Err(err) = rc_zip_tokio::ReadZip::read_zip(&bad_archive.as_slice()).await else {
+        // NOTE(cosmic): `.unwrap_err()` requires `ArchiveHandle` to impl `Debug`, but it doesn't
+        panic!("expected error, but parsed a valid archive");
+    };
+    assert_eq!(
+        err.to_string(),
+        "io: archive tried reading beyond zip archive end. 65536 goes beyond 42"
+    );
+}


### PR DESCRIPTION
fixes #102

constructing a cursor from a `&[u8]` or a `Vec<u8>` will blindly slice the... slice at whatever the provided offset is with no bounds checking which means that it will panic when there's an offset that's beyond the end of the slice. this pr adds explicit bounds checking before constructing a `CursorState` in the `rc-zip-{sync,tokio}` crates that returns an `Error::IO(_)` when out-of-bounds instead of panicking

from reading the code i believe that the `EntryReader` in both crates suffer from the same issue, and i haven't dug in deep enough to see if that one if fixable without api breakage. this issue doesn't happen on the `impl` that uses `positioned_io::Cursor` as the cursor, and that's probably the same for the async version that uses `AsyncRandomAcc...` as the cursor. i don't know how fundamental it is that `&[u8]` and `Vec<u8>` have `&[u8]` as the cursor. if it's possible to switch it to `std::io::Cursor<&[u8]>` then seeking could be infallible like all of the other cursors, and explicit bounds checking wouldn't be necessary as the failure is deferred to when the read happens afaik
