### PR TITLE
chore: placate clippy

### DIFF
--- a/rc-zip-sync/src/entry_reader.rs
+++ b/rc-zip-sync/src/entry_reader.rs
@@ -60,10 +60,7 @@ where
                         // progress was made, keep reading
                         continue;
                     } else {
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            "entry reader: no progress",
-                        ));
+                        return Err(io::Error::other("entry reader: no progress"));
                     }
                 }
                 FsmResult::Done(_) => {

--- a/rc-zip-tokio/src/entry_reader.rs
+++ b/rc-zip-tokio/src/entry_reader.rs
@@ -81,11 +81,7 @@ where
                         // progress was made, keep reading
                         continue;
                     } else {
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            "entry reader: no progress",
-                        ))
-                        .into();
+                        return Err(io::Error::other("entry reader: no progress")).into();
                     }
                 }
                 FsmResult::Done(_) => {

--- a/rc-zip-tokio/src/read_zip.rs
+++ b/rc-zip-tokio/src/read_zip.rs
@@ -344,10 +344,8 @@ impl AsyncRead for AsyncRandomAccessFileCursor {
                 self.poll_read(cx, buf)
             }
             ARAFCState::Reading { fut } => {
-                let core = futures_util::ready!(fut
-                    .as_mut()
-                    .poll(cx)
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))??);
+                let core =
+                    futures_util::ready!(fut.as_mut().poll(cx).map_err(io::Error::other)??);
                 let is_eof = core.inner_buf_len == 0;
                 self.state = ARAFCState::Idle(core);
 

--- a/rc-zip/src/error.rs
+++ b/rc-zip/src/error.rs
@@ -169,7 +169,7 @@ impl From<Error> for std::io::Error {
     fn from(e: Error) -> Self {
         match e {
             Error::IO(e) => e,
-            e => std::io::Error::new(std::io::ErrorKind::Other, e),
+            e => std::io::Error::other(e),
         }
     }
 }


### PR DESCRIPTION
this let's clippy rest once again

this project does use a toolchain file, so this could be denied in CI with a `-- -D warnings` or `env: RUSTFLAGS: "--deny warnings"` without fear of clippy randomly breaking things in the future