### PR TITLE
Update miniz_oxide to 0.8.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +91,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -460,15 +454,6 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
@@ -724,7 +709,7 @@ dependencies = [
  "deflate64",
  "encoding_rs",
  "lzma-rs",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "oem_cp",
  "oval",
  "ownable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures-util = "0.3.30"
 humansize = "2.1.3"
 indicatif = "0.17.7"
 lzma-rs = { version = "0.3.0", features = ["stream"] }
-miniz_oxide = "0.7.1"
+miniz_oxide = "0.8.9"
 oem_cp = "2.0.0"
 oval = "2.0.0"
 ownable = "0.6.2"


### PR DESCRIPTION
- This switches from adler (which is now unmaintained) to adler2