### PR TITLE
docs(rc-zip-sync): add a multi-threaded byte count example

### DIFF
--- a/rc-zip-sync/examples/byte_count.rs
+++ b/rc-zip-sync/examples/byte_count.rs
@@ -1,0 +1,173 @@
+use std::{ffi::OsString, fmt, fs::File, io::Read, sync::Mutex, thread, time};
+
+use rc_zip_sync::{ArchiveHandle, EntryHandle, ReadZip};
+
+/// Display counts for each byte in a zip's entries
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let zip_path = parse_args()?;
+    let zip_file = File::open(&zip_path)?;
+    let archive = zip_file.read_zip()?;
+
+    let start = time::Instant::now();
+    let counts = byte_count_multi_threaded(&archive);
+    print_stats(counts, start.elapsed());
+
+    Ok(())
+}
+
+fn parse_args() -> Result<OsString, &'static str> {
+    const USAGE: &str = "Usage: cargo run -r --example=byte_count -- [ZIP_FILE]";
+    let mut args = std::env::args_os();
+    let _bin = args.next();
+    let (Some(zip_path), None) = (args.next(), args.next()) else {
+        return Err(USAGE);
+    };
+    if zip_path
+        .to_str()
+        .is_some_and(|path| ["help", "--help", "-h"].contains(&path))
+    {
+        return Err(USAGE);
+    }
+
+    Ok(zip_path)
+}
+
+/// A count stored for each byte value where the index _is_ the byte value
+struct Counts([u64; 256]);
+
+impl Counts {
+    fn new() -> Self {
+        Self([0; _])
+    }
+
+    fn inc(&mut self, byte: u8) {
+        self.0[usize::from(byte)] += 1;
+    }
+
+    fn reduce(&mut self, other: &Self) {
+        for (sum, single) in self.0.iter_mut().zip(other.0.iter()) {
+            *sum += single;
+        }
+    }
+}
+
+/// Counts the number of each byte (0-255) in a zip's entries splitting the work across multiple
+/// threads
+///
+/// This is your typical map-reduce style problem. Things are _map_ed by creating the set of counts
+/// from a single entry in the zip file. Then the work is _reduce_d by combining the counts.
+///
+/// The work is split across a pool of worker threads where each worker takes turns fetching an
+/// entry from the archive to then read over the entry and reduce it down to counts. Then the final
+/// counts are totaled together as each worker finishes.
+fn byte_count_multi_threaded(archive: &ArchiveHandle<'_, File>) -> Counts {
+    let mut total_counts = Counts::new();
+    let entries = Mutex::new(archive.entries());
+    let num_workers = thread::available_parallelism().unwrap();
+    thread::scope(|s| {
+        let worker_handles: Vec<_> = (1..num_workers.into())
+            .map(|_| s.spawn(|| byte_count_worker(&entries)))
+            .collect();
+        total_counts = byte_count_worker(&entries);
+        for handle in worker_handles {
+            let counts = handle.join().unwrap();
+            total_counts.reduce(&counts);
+        }
+    });
+    let mut entries = entries.into_inner().unwrap();
+    assert!(
+        entries.next().is_none(),
+        "we should be finished and yet work remains. did all the workers die?"
+    );
+    total_counts
+}
+
+type ZipEntry<'zip> = EntryHandle<'zip, File>;
+
+fn byte_count_worker<'zip>(entries: &Mutex<impl Iterator<Item = ZipEntry<'zip>>>) -> Counts {
+    let mut local_counts = Counts::new();
+    loop {
+        let mut entries = entries.lock().unwrap();
+        let Some(entry) = entries.next() else {
+            // no more work!
+            break;
+        };
+        // !!IMPORTANT!! dropping the lock before handling the entry otherwise we're effectively
+        // single-threaded still :)
+        drop(entries);
+        if let Err(err) = entry_add_byte_counts(entry, &mut local_counts) {
+            eprintln!("error extracting entry: {err}");
+        }
+    }
+
+    local_counts
+}
+
+fn entry_add_byte_counts(entry: ZipEntry<'_>, counts: &mut Counts) -> rc_zip::Result<()> {
+    if entry.kind().is_file() {
+        let mut buf = [0; 8 * 1024];
+        let mut entry_reader = entry.reader();
+        while let Ok(num_bytes) = entry_reader.read(&mut buf) {
+            if num_bytes == 0 {
+                // finished reading!
+                break;
+            }
+            for byte in &buf[..num_bytes] {
+                counts.inc(*byte);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct Byte(u8);
+
+impl fmt::Display for Byte {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let byte = self.0;
+        if byte.is_ascii_graphic() {
+            write!(f, "{:<4}", char::from(byte))
+        } else {
+            write!(f, "0x{byte:02x}")
+        }
+    }
+}
+
+struct Bar(u64, u64);
+
+impl fmt::Display for Bar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const LENGTH: f32 = 60.0;
+
+        let &Self(count, max) = self;
+        let percentage = count as f32 / max as f32;
+        let block_length = (LENGTH * percentage).floor() as usize;
+        for _ in 0..block_length {
+            f.write_str("█")?;
+        }
+
+        let block_sections = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"];
+        let index = (((LENGTH * percentage) - block_length as f32) * 8.0).round() as usize;
+        f.write_str(block_sections[index])
+    }
+}
+
+fn print_stats(counts: Counts, took: time::Duration) {
+    let counts = counts.0;
+
+    let max = counts.into_iter().max().unwrap();
+    let total: u64 = counts.into_iter().sum();
+    println!("┏━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━");
+    println!("┃ byte ┃ perc.  ┃   count   ┃ bar");
+    println!("┣━━━━━━╋━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━━");
+    for (byte, count) in counts.into_iter().enumerate() {
+        let byte = Byte(byte.try_into().unwrap());
+
+        let percent = count as f32 / total as f32 * 100.0;
+        let bar = Bar(count, max);
+        println!("┃ {byte} ┃ {percent:>5.2}% ┃ {count:>9} ┃ {bar}");
+    }
+    println!("┗━━━━━━┻━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━━");
+    println!("Counted {total} bytes in {took:.2?}");
+}


### PR DESCRIPTION
another example that was quite fun :fairy:

i have a program where i do a similar-ish thing of extracting some info from a zip file with a pool of worker threads, and i figured it would be nice to have it as an example

<details>

<summary><code>$ cargo run -rq --example=byte_count -- &lt;crates.io db-dump zip file&gt;</code></summary>

```
┏━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━
┃ byte ┃ perc.  ┃   count   ┃ bar
┣━━━━━━╋━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━━
┃ 0x00 ┃  0.00% ┃     39084 ┃
┃ 0x01 ┃  0.00% ┃         7 ┃
┃ 0x02 ┃  0.00% ┃         0 ┃
┃ 0x03 ┃  0.00% ┃         0 ┃
┃ 0x04 ┃  0.00% ┃         0 ┃
┃ 0x05 ┃  0.00% ┃         0 ┃
┃ 0x06 ┃  0.00% ┃         0 ┃
┃ 0x07 ┃  0.00% ┃         0 ┃
┃ 0x08 ┃  0.00% ┃         2 ┃
┃ 0x09 ┃  0.00% ┃     67410 ┃
┃ 0x0a ┃  3.24% ┃ 144299177 ┃ ███████████████████▎
┃ 0x0b ┃  0.00% ┃         0 ┃
┃ 0x0c ┃  0.00% ┃         2 ┃
┃ 0x0d ┃  0.02% ┃   1015093 ┃ ▏
┃ 0x0e ┃  0.00% ┃         0 ┃
┃ 0x0f ┃  0.00% ┃         0 ┃
┃ 0x10 ┃  0.00% ┃        17 ┃
┃ 0x11 ┃  0.00% ┃         1 ┃
┃ 0x12 ┃  0.00% ┃         0 ┃
┃ 0x13 ┃  0.00% ┃         0 ┃
┃ 0x14 ┃  0.00% ┃         1 ┃
┃ 0x15 ┃  0.00% ┃         0 ┃
┃ 0x16 ┃  0.00% ┃         0 ┃
┃ 0x17 ┃  0.00% ┃         0 ┃
┃ 0x18 ┃  0.00% ┃         0 ┃
┃ 0x19 ┃  0.00% ┃         0 ┃
┃ 0x1a ┃  0.00% ┃         1 ┃
┃ 0x1b ┃  0.00% ┃       247 ┃
┃ 0x1c ┃  0.00% ┃         0 ┃
┃ 0x1d ┃  0.00% ┃         0 ┃
┃ 0x1e ┃  0.00% ┃         9 ┃
┃ 0x1f ┃  0.00% ┃         1 ┃
┃ 0x20 ┃  2.03% ┃  90286019 ┃ ████████████
┃ !    ┃  0.01% ┃    530240 ┃ ▏
┃ "    ┃  1.56% ┃  69547133 ┃ █████████▎
┃ #    ┃  0.05% ┃   2057356 ┃ ▎
┃ $    ┃  0.00% ┃     94449 ┃
┃ %    ┃  0.00% ┃    106593 ┃
┃ &    ┃  0.01% ┃    264013 ┃
┃ '    ┃  0.01% ┃    384890 ┃
┃ (    ┃  0.08% ┃   3458299 ┃ ▌
┃ )    ┃  0.08% ┃   3463034 ┃ ▌
┃ *    ┃  0.04% ┃   1691226 ┃ ▎
┃ +    ┃  0.10% ┃   4340249 ┃ ▋
┃ ,    ┃ 10.06% ┃ 447785929 ┃ ███████████████████████████████████████████████████████████▌
┃ -    ┃  5.74% ┃ 255504358 ┃ ██████████████████████████████████
┃ .    ┃  1.14% ┃  50933772 ┃ ██████▊
┃ /    ┃  0.47% ┃  21003171 ┃ ██▊
┃ 0    ┃  9.93% ┃ 442060269 ┃ ██████████████████████████████████████████████████████████▊
┃ 1    ┃  7.38% ┃ 328427817 ┃ ███████████████████████████████████████████▋
┃ 2    ┃ 10.13% ┃ 451187564 ┃ ████████████████████████████████████████████████████████████
┃ 3    ┃  3.74% ┃ 166720421 ┃ ██████████████████████▏
┃ 4    ┃  3.31% ┃ 147277740 ┃ ███████████████████▋
┃ 5    ┃  5.72% ┃ 254598660 ┃ █████████████████████████████████▉
┃ 6    ┃  3.06% ┃ 136469466 ┃ ██████████████████▏
┃ 7    ┃  3.51% ┃ 156422316 ┃ ████████████████████▊
┃ 8    ┃  3.71% ┃ 164981222 ┃ ██████████████████████
┃ 9    ┃  3.58% ┃ 159281729 ┃ █████████████████████▏
┃ :    ┃  0.49% ┃  21909769 ┃ ██▉
┃ ;    ┃  0.02% ┃    808297 ┃ ▏
┃ <    ┃  0.02% ┃    731892 ┃ ▏
┃ =    ┃  0.05% ┃   2346646 ┃ ▎
┃ >    ┃  0.02% ┃    950519 ┃ ▏
┃ ?    ┃  0.01% ┃    388053 ┃
┃ @    ┃  0.00% ┃     46387 ┃
┃ A    ┃  0.08% ┃   3676767 ┃ ▌
┃ B    ┃  0.03% ┃   1544429 ┃ ▎
┃ C    ┃  0.06% ┃   2771347 ┃ ▍
┃ D    ┃  0.04% ┃   1795369 ┃ ▎
┃ E    ┃  0.04% ┃   1631042 ┃ ▎
┃ F    ┃  0.03% ┃   1488133 ┃ ▎
┃ G    ┃  0.02% ┃    929849 ┃ ▏
┃ H    ┃  0.02% ┃    830459 ┃ ▏
┃ I    ┃  0.07% ┃   3249247 ┃ ▍
┃ J    ┃  0.01% ┃    247563 ┃
┃ K    ┃  0.01% ┃    408323 ┃
┃ L    ┃  0.05% ┃   2090714 ┃ ▎
┃ M    ┃  0.06% ┃   2607776 ┃ ▍
┃ N    ┃  0.02% ┃   1045263 ┃ ▏
┃ O    ┃  0.04% ┃   1560387 ┃ ▎
┃ P    ┃  0.05% ┃   2017312 ┃ ▎
┃ Q    ┃  0.00% ┃    219132 ┃
┃ R    ┃  0.06% ┃   2544893 ┃ ▍
┃ S    ┃  0.09% ┃   3786427 ┃ ▌
┃ T    ┃  0.08% ┃   3718777 ┃ ▌
┃ U    ┃  0.02% ┃    831563 ┃ ▏
┃ V    ┃  0.01% ┃    579659 ┃ ▏
┃ W    ┃  0.02% ┃    881133 ┃ ▏
┃ X    ┃  0.01% ┃    224860 ┃
┃ Y    ┃  0.00% ┃    214617 ┃
┃ Z    ┃  0.00% ┃    126353 ┃
┃ [    ┃  0.16% ┃   7189135 ┃ █
┃ \    ┃  0.00% ┃    109751 ┃
┃ ]    ┃  0.16% ┃   7187584 ┃ █
┃ ^    ┃  0.38% ┃  16855154 ┃ ██▎
┃ _    ┃  0.18% ┃   7855087 ┃ █
┃ `    ┃  0.11% ┃   4697163 ┃ ▋
┃ a    ┃  1.28% ┃  57057574 ┃ ███████▋
┃ b    ┃  0.45% ┃  20211168 ┃ ██▊
┃ c    ┃  0.88% ┃  39107115 ┃ █████▎
┃ d    ┃  0.73% ┃  32302211 ┃ ████▎
┃ e    ┃  1.81% ┃  80565476 ┃ ██████████▊
┃ f    ┃  0.86% ┃  38277386 ┃ █████▏
┃ g    ┃  0.48% ┃  21243886 ┃ ██▉
┃ h    ┃  0.48% ┃  21436113 ┃ ██▉
┃ i    ┃  1.11% ┃  49210153 ┃ ██████▌
┃ j    ┃  0.03% ┃   1424877 ┃ ▎
┃ k    ┃  0.13% ┃   5841208 ┃ ▊
┃ l    ┃  0.74% ┃  33101742 ┃ ████▍
┃ m    ┃  0.50% ┃  22267534 ┃ ███
┃ n    ┃  0.90% ┃  39898094 ┃ █████▎
┃ o    ┃  1.16% ┃  51841850 ┃ ██████▉
┃ p    ┃  0.56% ┃  24885001 ┃ ███▎
┃ q    ┃  0.03% ┃   1395694 ┃ ▏
┃ r    ┃  1.07% ┃  47864160 ┃ ██████▍
┃ s    ┃  1.14% ┃  50949977 ┃ ██████▊
┃ t    ┃  1.93% ┃  85797199 ┃ ███████████▍
┃ u    ┃  0.53% ┃  23411709 ┃ ███▏
┃ v    ┃  0.18% ┃   8174659 ┃ █▏
┃ w    ┃  0.17% ┃   7661905 ┃ █
┃ x    ┃  0.08% ┃   3625267 ┃ ▌
┃ y    ┃  0.22% ┃   9864723 ┃ █▎
┃ z    ┃  0.04% ┃   1641683 ┃ ▎
┃ {    ┃  0.57% ┃  25304220 ┃ ███▍
┃ |    ┃  0.02% ┃    881680 ┃ ▏
┃ }    ┃  0.57% ┃  25302726 ┃ ███▍
┃ ~    ┃  0.01% ┃    249442 ┃
┃ 0x7f ┃  0.00% ┃         1 ┃
┃ 0x80 ┃  0.01% ┃    435003 ┃
┃ 0x81 ┃  0.00% ┃     90816 ┃
┃ 0x82 ┃  0.00% ┃    135529 ┃
┃ 0x83 ┃  0.00% ┃     52366 ┃
┃ 0x84 ┃  0.00% ┃     49167 ┃
┃ 0x85 ┃  0.00% ┃     56574 ┃
┃ 0x86 ┃  0.00% ┃     38321 ┃
┃ 0x87 ┃  0.00% ┃     35636 ┃
┃ 0x88 ┃  0.00% ┃     74115 ┃
┃ 0x89 ┃  0.00% ┃     34276 ┃
┃ 0x8a ┃  0.00% ┃     25168 ┃
┃ 0x8b ┃  0.00% ┃     34151 ┃
┃ 0x8c ┃  0.00% ┃     90939 ┃
┃ 0x8d ┃  0.00% ┃     36025 ┃
┃ 0x8e ┃  0.00% ┃     32508 ┃
┃ 0x8f ┃  0.00% ┃     67624 ┃
┃ 0x90 ┃  0.00% ┃     69108 ┃
┃ 0x91 ┃  0.00% ┃     35611 ┃
┃ 0x92 ┃  0.00% ┃     27396 ┃
┃ 0x93 ┃  0.00% ┃     47915 ┃
┃ 0x94 ┃  0.01% ┃    489742 ┃ ▏
┃ 0x95 ┃  0.00% ┃     93168 ┃
┃ 0x96 ┃  0.00% ┃     80913 ┃
┃ 0x97 ┃  0.00% ┃     32170 ┃
┃ 0x98 ┃  0.00% ┃     29695 ┃
┃ 0x99 ┃  0.00% ┃     31326 ┃
┃ 0x9a ┃  0.00% ┃     64606 ┃
┃ 0x9b ┃  0.00% ┃     28229 ┃
┃ 0x9c ┃  0.00% ┃     92052 ┃
┃ 0x9d ┃  0.00% ┃     37256 ┃
┃ 0x9e ┃  0.00% ┃     23308 ┃
┃ 0x9f ┃  0.00% ┃    117186 ┃
┃ 0xa0 ┃  0.00% ┃     56802 ┃
┃ 0xa1 ┃  0.00% ┃     41475 ┃
┃ 0xa2 ┃  0.00% ┃     21421 ┃
┃ 0xa3 ┃  0.00% ┃     20325 ┃
┃ 0xa4 ┃  0.00% ┃     35594 ┃
┃ 0xa5 ┃  0.00% ┃     28358 ┃
┃ 0xa6 ┃  0.00% ┃     27354 ┃
┃ 0xa7 ┃  0.00% ┃     32331 ┃
┃ 0xa8 ┃  0.00% ┃     47675 ┃
┃ 0xa9 ┃  0.00% ┃     17733 ┃
┃ 0xaa ┃  0.00% ┃     20654 ┃
┃ 0xab ┃  0.00% ┃     16534 ┃
┃ 0xac ┃  0.00% ┃     20898 ┃
┃ 0xad ┃  0.00% ┃     25671 ┃
┃ 0xae ┃  0.00% ┃     53979 ┃
┃ 0xaf ┃  0.00% ┃     52830 ┃
┃ 0xb0 ┃  0.00% ┃     45960 ┃
┃ 0xb1 ┃  0.00% ┃     20774 ┃
┃ 0xb2 ┃  0.00% ┃     14219 ┃
┃ 0xb3 ┃  0.00% ┃     23214 ┃
┃ 0xb4 ┃  0.00% ┃     23782 ┃
┃ 0xb5 ┃  0.00% ┃     33292 ┃
┃ 0xb6 ┃  0.00% ┃     24269 ┃
┃ 0xb7 ┃  0.00% ┃     25405 ┃
┃ 0xb8 ┃  0.00% ┃     81698 ┃
┃ 0xb9 ┃  0.00% ┃     30978 ┃
┃ 0xba ┃  0.00% ┃     51394 ┃
┃ 0xbb ┃  0.00% ┃     56674 ┃
┃ 0xbc ┃  0.00% ┃     73003 ┃
┃ 0xbd ┃  0.00% ┃     51659 ┃
┃ 0xbe ┃  0.00% ┃     41283 ┃
┃ 0xbf ┃  0.00% ┃     40551 ┃
┃ 0xc0 ┃  0.00% ┃         0 ┃
┃ 0xc1 ┃  0.00% ┃         0 ┃
┃ 0xc2 ┃  0.00% ┃     27761 ┃
┃ 0xc3 ┃  0.00% ┃     22740 ┃
┃ 0xc4 ┃  0.00% ┃      3411 ┃
┃ 0xc5 ┃  0.00% ┃      2514 ┃
┃ 0xc6 ┃  0.00% ┃       119 ┃
┃ 0xc7 ┃  0.00% ┃       114 ┃
┃ 0xc8 ┃  0.00% ┃        37 ┃
┃ 0xc9 ┃  0.00% ┃       772 ┃
┃ 0xca ┃  0.00% ┃       240 ┃
┃ 0xcb ┃  0.00% ┃       502 ┃
┃ 0xcc ┃  0.00% ┃      5383 ┃
┃ 0xcd ┃  0.00% ┃      2428 ┃
┃ 0xce ┃  0.00% ┃      8660 ┃
┃ 0xcf ┃  0.00% ┃      2089 ┃
┃ 0xd0 ┃  0.00% ┃    120514 ┃
┃ 0xd1 ┃  0.00% ┃     51512 ┃
┃ 0xd2 ┃  0.00% ┃        20 ┃
┃ 0xd3 ┃  0.00% ┃        12 ┃
┃ 0xd4 ┃  0.00% ┃        25 ┃
┃ 0xd5 ┃  0.00% ┃        43 ┃
┃ 0xd6 ┃  0.00% ┃       111 ┃
┃ 0xd7 ┃  0.00% ┃       617 ┃
┃ 0xd8 ┃  0.00% ┃      2785 ┃
┃ 0xd9 ┃  0.00% ┃      1912 ┃
┃ 0xda ┃  0.00% ┃       153 ┃
┃ 0xdb ┃  0.00% ┃       414 ┃
┃ 0xdc ┃  0.00% ┃         0 ┃
┃ 0xdd ┃  0.00% ┃        17 ┃
┃ 0xde ┃  0.00% ┃         0 ┃
┃ 0xdf ┃  0.00% ┃        39 ┃
┃ 0xe0 ┃  0.00% ┃      4822 ┃
┃ 0xe1 ┃  0.00% ┃      1892 ┃
┃ 0xe2 ┃  0.02% ┃    684735 ┃ ▏
┃ 0xe3 ┃  0.00% ┃    115607 ┃
┃ 0xe4 ┃  0.00% ┃     96858 ┃
┃ 0xe5 ┃  0.00% ┃    213910 ┃
┃ 0xe6 ┃  0.00% ┃    155485 ┃
┃ 0xe7 ┃  0.00% ┃    118824 ┃
┃ 0xe8 ┃  0.00% ┃     85658 ┃
┃ 0xe9 ┃  0.00% ┃     46099 ┃
┃ 0xea ┃  0.00% ┃      3177 ┃
┃ 0xeb ┃  0.00% ┃      9075 ┃
┃ 0xec ┃  0.00% ┃     13006 ┃
┃ 0xed ┃  0.00% ┃      4832 ┃
┃ 0xee ┃  0.00% ┃       382 ┃
┃ 0xef ┃  0.00% ┃     54261 ┃
┃ 0xf0 ┃  0.00% ┃     91048 ┃
┃ 0xf1 ┃  0.00% ┃         7 ┃
┃ 0xf2 ┃  0.00% ┃         3 ┃
┃ 0xf3 ┃  0.00% ┃       106 ┃
┃ 0xf4 ┃  0.00% ┃         2 ┃
┃ 0xf5 ┃  0.00% ┃         0 ┃
┃ 0xf6 ┃  0.00% ┃         0 ┃
┃ 0xf7 ┃  0.00% ┃         0 ┃
┃ 0xf8 ┃  0.00% ┃         0 ┃
┃ 0xf9 ┃  0.00% ┃         0 ┃
┃ 0xfa ┃  0.00% ┃         0 ┃
┃ 0xfb ┃  0.00% ┃         0 ┃
┃ 0xfc ┃  0.00% ┃         0 ┃
┃ 0xfd ┃  0.00% ┃         0 ┃
┃ 0xfe ┃  0.00% ┃         0 ┃
┃ 0xff ┃  0.00% ┃         0 ┃
┗━━━━━━┻━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━━
Counted 4452892672 bytes in 7.58s
```

</details>