### PR TITLE
test(rc-zip-cli): test unzip{,-streaming} against corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,8 +636,12 @@ dependencies = [
  "humansize",
  "indicatif",
  "rc-zip",
+ "rc-zip-corpus",
  "rc-zip-sync",
+ "temp-dir",
+ "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -699,6 +703,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -867,6 +880,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +968,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,6 @@ thiserror = "2.0.17"
 tokio = { version = "1.43.1", features = ["fs", "io-util", "rt"] }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+walkdir = "2.5.0"
 winnow = "0.5.36"
 zstd = "0.13.0"

--- a/rc-zip-cli/Cargo.toml
+++ b/rc-zip-cli/Cargo.toml
@@ -31,3 +31,9 @@ humansize.workspace = true
 indicatif.workspace = true
 tracing-subscriber.workspace = true
 cfg-if.workspace = true
+
+[dev-dependencies]
+rc-zip-corpus.workspace = true
+temp-dir.workspace = true
+tracing.workspace = true
+walkdir.workspace = true

--- a/rc-zip-cli/src/test.rs
+++ b/rc-zip-cli/src/test.rs
@@ -1,0 +1,97 @@
+use std::path::Path;
+
+use crate::{unzip, unzip_streaming};
+
+use rc_zip_corpus::{zips_dir, Case, CaseFile, FileContent, Files};
+use temp_dir::TempDir;
+use walkdir::WalkDir;
+
+fn check_case(
+    case: &Case,
+    unzip_fn: fn(&Path, Option<&Path>, bool) -> Result<(), Box<dyn std::error::Error>>,
+) {
+    let out_dir = TempDir::with_prefix("rc-zip-test-").unwrap();
+    let out_path = out_dir.path();
+
+    let guarded_path = case.absolute_path();
+    let zip_path = &guarded_path.path;
+
+    let hide_progress = true;
+    let res = (unzip_fn)(zip_path, Some(out_path), hide_progress);
+    match (res, &case.error) {
+        (Ok(()), None) => { /* checked after */ }
+        (Err(actual), Some(expected)) => {
+            let expected = format!("{:#?}", expected);
+            let actual = format!("{:#?}", actual);
+            assert_eq!(expected, actual);
+            return;
+        }
+        (Ok(()), Some(expected)) => panic!("succeeded, but should have failed with {expected:?}"),
+        (Err(actual), None) => panic!("should have succeeded, but failed with {actual:?}"),
+    }
+
+    match &case.files {
+        Files::NumFiles(expected) => {
+            // `WalkDir` includes the directory itself, so `- 1` to account for it
+            let actual = WalkDir::new(out_path).into_iter().count() - 1;
+            assert_eq!(*expected, actual);
+        }
+        Files::ExhaustiveList(files) => {
+            for file in files {
+                let CaseFile {
+                    name,
+                    mode,
+                    modified,
+                    content,
+                } = file;
+                let extracted_path = out_path.join(name);
+
+                match content {
+                    FileContent::Unchecked => assert!(
+                        extracted_path.exists(),
+                        "expected {name} to exist, but it didn't"
+                    ),
+                    FileContent::Bytes(expected) => {
+                        let actual = std::fs::read(&extracted_path).unwrap();
+                        assert_eq!(expected.len(), actual.len());
+                        assert_eq!(expected, &actual);
+                    }
+                    FileContent::File(expected_path) => {
+                        let actual = std::fs::read(&extracted_path).unwrap();
+                        let expected = std::fs::read(zips_dir().join(expected_path)).unwrap();
+                        assert_eq!(expected.len(), actual.len());
+                        assert_eq!(expected, actual);
+                    }
+                }
+
+                if let Some(_expected) = mode {
+                    // TODO(cosmic): platform specific behavior makes this non-trivial to test :S
+                }
+
+                if let Some(_expected) = modified {
+                    // FIXME(cosmic): unsupported (for now)
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn corpus() {
+    rc_zip_corpus::install_test_subscriber();
+
+    for case in rc_zip_corpus::test_cases() {
+        tracing::info!("============ testing {}", case.name);
+        check_case(&case, unzip);
+    }
+}
+
+#[test]
+fn corpus_streaming() {
+    rc_zip_corpus::install_test_subscriber();
+
+    for case in rc_zip_corpus::streaming_test_cases() {
+        tracing::info!("============ testing {}", case.name);
+        check_case(&case, unzip_streaming);
+    }
+}


### PR DESCRIPTION
_(best reviewed one commit at a time)_

wires things up to test the unzipped directory from `rc-zip-cli unzip{,-streaming} <corpus_file>` against the corpus test cases. test coverage go :chart_with_upwards_trend::chart_with_upwards_trend::chart_with_upwards_trend: 