### PR TITLE
perf: reduce allocations in `rc_zip_{tokio,sync}::EntryHandle::bytes`

### DIFF
--- a/rc-zip-sync/src/read_zip.rs
+++ b/rc-zip-sync/src/read_zip.rs
@@ -196,7 +196,8 @@ where
 
     /// Reads the entire entry into a vector.
     pub fn bytes(&self) -> std::io::Result<Vec<u8>> {
-        let mut v = Vec::new();
+        let size = self.uncompressed_size.try_into().unwrap_or(0);
+        let mut v = Vec::with_capacity(size);
         self.reader().read_to_end(&mut v)?;
         Ok(v)
     }

--- a/rc-zip-tokio/src/read_zip.rs
+++ b/rc-zip-tokio/src/read_zip.rs
@@ -211,7 +211,8 @@ where
 
     /// Reads the entire entry into a vector.
     pub async fn bytes(&self) -> io::Result<Vec<u8>> {
-        let mut v = Vec::new();
+        let size = self.uncompressed_size.try_into().unwrap_or(0);
+        let mut v = Vec::with_capacity(size);
         self.reader().read_to_end(&mut v).await?;
         Ok(v)
     }


### PR DESCRIPTION
since it should match the decompressed size