### PR TITLE
Allow ArchiveHandle to own its data

### DIFF
--- a/rc-zip-cli/src/main.rs
+++ b/rc-zip-cli/src/main.rs
@@ -136,7 +136,7 @@ fn info(out: &mut impl io::Write, archive: &Archive) -> io::Result<()> {
 
 fn list(
     out: &mut impl io::Write,
-    archive: &ArchiveHandle<'_, File>,
+    archive: &ArchiveHandle<File>,
     verbose: bool,
 ) -> io::Result<()> {
     for entry in archive.entries() {

--- a/rc-zip-sync/benches/read.rs
+++ b/rc-zip-sync/benches/read.rs
@@ -1,4 +1,4 @@
-use std::{hint::black_box, time::Duration};
+use std::{hint::black_box, ops::Deref, time::Duration};
 
 use divan::{bench, counter::ItemsCount, Bencher, Divan};
 use rc_zip_corpus::test_cases;
@@ -15,10 +15,10 @@ fn main() {
 fn archive_entries(bencher: Bencher, name: &'static str) {
     let case = test_cases().into_iter().find(|c| c.name == name).unwrap();
     let zip_contents = case.bytes();
-    let archive = zip_contents.read_zip().unwrap();
+    let archive = zip_contents.deref().read_zip().unwrap();
     let num_entries = ItemsCount::new(archive.entries().count());
 
     bencher
         .counter(num_entries)
-        .bench(|| black_box(&zip_contents).read_zip().unwrap());
+        .bench(|| black_box(zip_contents.deref()).read_zip().unwrap());
 }

--- a/rc-zip-sync/examples/byte_count.rs
+++ b/rc-zip-sync/examples/byte_count.rs
@@ -60,7 +60,7 @@ impl Counts {
 /// The work is split across a pool of worker threads where each worker takes turns fetching an
 /// entry from the archive to then read over the entry and reduce it down to counts. Then the final
 /// counts are totaled together as each worker finishes.
-fn byte_count_multi_threaded(archive: &ArchiveHandle<'_, File>) -> Counts {
+fn byte_count_multi_threaded(archive: &ArchiveHandle<File>) -> Counts {
     let mut total_counts = Counts::new();
     let entries = Mutex::new(archive.entries());
     let num_workers = thread::available_parallelism().unwrap();

--- a/rc-zip-sync/examples/self_extracting.rs
+++ b/rc-zip-sync/examples/self_extracting.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
+fn extract(archive: &ArchiveHandle<File>) -> Result<(), Error> {
     for entry in archive.entries() {
         println!("extracting {}", entry.name);
         let Some(entry_name) = entry.sanitized_name() else {

--- a/rc-zip-sync/tests/integration_tests.rs
+++ b/rc-zip-sync/tests/integration_tests.rs
@@ -7,7 +7,7 @@ use std::{
     io::{self, Read},
 };
 
-fn check_case<F: HasCursor>(test: &Case, archive: Result<ArchiveHandle<'_, F>, Error>) {
+fn check_case<F: HasCursor>(test: &Case, archive: Result<ArchiveHandle<F>, Error>) {
     rc_zip_corpus::check_case(test, archive.as_ref().map(|ar| -> &Archive { ar }));
     let archive = match archive {
         Ok(archive) => archive,


### PR DESCRIPTION
This allows the creation of `ArchiveHandle`s which own their backing data store, allowing them to be passed around more freely without the need for complex solutions such as [yoke](https://docs.rs/yoke]). For borrowed data, references to both slices and file handles are still valid data sources, preserving existing functionality. Originally discussed in #134.

Currently implemented for rc-zip-sync only. Will implement this for rc-zip-tokio before marking this ready.

Breaking Changes:
* The type previously referred to as `ArchiveHandle<'a, F>` is now `ArchiveHandle<&'a F>`.
* `file.read_zip()` now consumes the file instead of borrowing it if file is owned. The old functionality can be accessed inline with `file.borrow().read_zip()`.
* Creating an ArchiveHandle from in-memory data now requires a `&[u8]` instead of `&&[u8]`