### PR TITLE
feat: permit owned iteration over entries

### DIFF
--- a/rc-zip-sync/examples/self_extracting.rs
+++ b/rc-zip-sync/examples/self_extracting.rs
@@ -74,9 +74,9 @@ fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
                     use std::ffi::OsString;
                     use std::os::unix::ffi::OsStringExt;
 
-                    if let Ok(metadata) = fs::symlink_metadata(&path) {
+                    if let Ok(metadata) = fs::symlink_metadata(path) {
                         if metadata.is_file() {
-                            fs::remove_file(&path)?;
+                            fs::remove_file(path)?;
                         }
                     }
 
@@ -84,7 +84,7 @@ fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
                     entry.reader().read_to_end(&mut src)?;
                     let src = OsString::from_vec(src);
 
-                    std::os::unix::fs::symlink(&src, &path)?;
+                    std::os::unix::fs::symlink(&src, path)?;
                 }
                 #[cfg(not(any(windows, unix)))]
                 {

--- a/rc-zip-sync/tests/integration_tests.rs
+++ b/rc-zip-sync/tests/integration_tests.rs
@@ -64,10 +64,10 @@ fn real_world_files() {
         if let Ok("1") = std::env::var("ONE_BYTE_READ").as_deref() {
             let size = file.metadata().unwrap().len();
             let file = OneByteReadWrapper(file);
-            let archive = file.read_zip_with_size(size).map_err(Error::from);
+            let archive = file.read_zip_with_size(size);
             check_case(&case, archive);
         } else {
-            let archive = file.read_zip().map_err(Error::from);
+            let archive = file.read_zip();
             check_case(&case, archive);
         };
         drop(guarded_path)

--- a/rc-zip/src/parse/archive.rs
+++ b/rc-zip/src/parse/archive.rs
@@ -32,6 +32,11 @@ impl Archive {
         self.size
     }
 
+    /// Owning iterator over all files in this zip, read from the central directory.
+    pub fn into_entries(self) -> impl Iterator<Item = Entry> {
+        self.entries.into_iter()
+    }
+
     /// Iterate over all files in this zip, read from the central directory.
     pub fn entries(&self) -> impl Iterator<Item = &Entry> {
         self.entries.iter()


### PR DESCRIPTION
We needed an `EntryHandle` that owned its reader. This required a fork of `rc-zip-sync` but it isn't clear if we want to go through the process of upstreaming that patch just yet.

A prerequisite for this is owning the iterator over the entries, so this is the small modification we had to do to `rc-zip` itself.