### PR TITLE
feat: allow retrieving longer borrow of Entry

### DIFF
--- a/rc-zip-sync/src/read_zip.rs
+++ b/rc-zip-sync/src/read_zip.rs
@@ -189,6 +189,10 @@ impl<'a, F> EntryHandle<'a, F>
 where
     F: HasCursor,
 {
+    /// Get the underlying `Entry`
+    pub fn entry(&self) -> &'a Entry {
+        self.entry
+    }
     /// Returns a reader for the entry.
     pub fn reader(&self) -> EntryReader<<F as HasCursor>::Cursor<'a>> {
         EntryReader::new(self.entry, self.file.cursor_at(self.entry.header_offset))

--- a/rc-zip-sync/tests/integration_tests.rs
+++ b/rc-zip-sync/tests/integration_tests.rs
@@ -37,7 +37,9 @@ fn read_from_slice() {
     assert_eq!(archive.entries().count(), 2);
 
     // test that we can build an iterator over file names
-    fn consume_file_names<'a>(_file_names: impl Iterator<Item = &'a String>) {}
+    fn consume_file_names<'a>(file_names: impl Iterator<Item = &'a String>) {
+        assert_eq!(file_names.count(), 2);
+    }
     consume_file_names(archive.entries().map(|entr| &entr.entry().name));
 }
 

--- a/rc-zip-sync/tests/integration_tests.rs
+++ b/rc-zip-sync/tests/integration_tests.rs
@@ -35,6 +35,10 @@ fn read_from_slice() {
     let slice = &bytes[..];
     let archive = slice.read_zip().unwrap();
     assert_eq!(archive.entries().count(), 2);
+
+    // test that we can build an iterator over file names
+    fn consume_file_names<'a>(_file_names: impl Iterator<Item = &'a String>) {}
+    consume_file_names(archive.entries().map(|entr| &entr.entry().name));
 }
 
 #[test]

--- a/rc-zip-tokio/src/read_zip.rs
+++ b/rc-zip-tokio/src/read_zip.rs
@@ -204,6 +204,11 @@ impl<'a, F> EntryHandle<'a, F>
 where
     F: HasCursor,
 {
+    /// Get the underlying `Entry`
+    pub fn entry(&self) -> &'a Entry {
+        self.entry
+    }
+
     /// Returns a reader for the entry.
     pub fn reader(&self) -> impl AsyncRead + Unpin + '_ {
         EntryReader::new(self.entry, |offset| self.file.cursor_at(offset))

--- a/rc-zip-tokio/tests/integration_tests.rs
+++ b/rc-zip-tokio/tests/integration_tests.rs
@@ -32,6 +32,10 @@ async fn read_from_slice() {
     let slice = &bytes[..];
     let archive = slice.read_zip().await.unwrap();
     assert_eq!(archive.entries().count(), 2);
+
+    // test that we can build an iterator over file names
+    fn consume_file_names<'a>(_file_names: impl Iterator<Item = &'a String>) {}
+    consume_file_names(archive.entries().map(|entr| &entr.entry().name));
 }
 
 #[tokio::test]

--- a/rc-zip-tokio/tests/integration_tests.rs
+++ b/rc-zip-tokio/tests/integration_tests.rs
@@ -34,7 +34,9 @@ async fn read_from_slice() {
     assert_eq!(archive.entries().count(), 2);
 
     // test that we can build an iterator over file names
-    fn consume_file_names<'a>(_file_names: impl Iterator<Item = &'a String>) {}
+    fn consume_file_names<'a>(file_names: impl Iterator<Item = &'a String>) {
+        assert_eq!(file_names.count(), 2);
+    }
     consume_file_names(archive.entries().map(|entr| &entr.entry().name));
 }
 


### PR DESCRIPTION
With this method it is now possible to emulate `fn file_names()` from the `zip` crate.

Alternatives would be to special case the method and provide a real `fn file_names()`, but by returning a longer lifetime we can also iterate over other fields of `Entry` if necessary.