### PR TITLE
WIP: less generic API

### DIFF
--- a/rc-zip-cli/src/main.rs
+++ b/rc-zip-cli/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use humansize::{format_size, BINARY};
 use indicatif::{ProgressBar, ProgressStyle};
 use rc_zip::{Archive, Entry, EntryKind};
-use rc_zip_sync::{ArchiveHandle, ReadZip, ReadZipStreaming};
+use rc_zip_sync::{HasCursor, ReadZip, ReadZipStreaming};
 
 use std::{
     borrow::Cow,
@@ -81,10 +81,10 @@ fn do_main(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Ls { zipfile, verbose } => {
             let zipfile = File::open(zipfile)?;
-            let reader = zipfile.read_zip()?;
+            let archive = zipfile.read_zip()?;
             let mut stdout = io::stdout().lock();
-            let _ = info(&mut stdout, &reader);
-            let _ = list(&mut stdout, &reader, verbose);
+            let _ = info(&mut stdout, &archive);
+            let _ = list(&mut stdout, &zipfile, &archive, verbose);
         }
         Commands::Unzip { zipfile, dir } => unzip(&zipfile, dir.as_deref(), false)?,
         Commands::UnzipStreaming { zipfile, dir } => {
@@ -134,11 +134,7 @@ fn info(out: &mut impl io::Write, archive: &Archive) -> io::Result<()> {
     Ok(())
 }
 
-fn list(
-    out: &mut impl io::Write,
-    archive: &ArchiveHandle<'_, File>,
-    verbose: bool,
-) -> io::Result<()> {
+fn list(out: &mut impl io::Write, f: &File, archive: &Archive, verbose: bool) -> io::Result<()> {
     for entry in archive.entries() {
         write!(
             out,
@@ -167,7 +163,7 @@ fn list(
 
             if let EntryKind::Symlink = entry.kind() {
                 let mut target = String::new();
-                entry.reader().read_to_string(&mut target).unwrap();
+                f.reader_at(entry).read_to_string(&mut target).unwrap();
                 print!("\t{target}", target = target);
             }
 
@@ -189,10 +185,10 @@ fn unzip(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let zipfile = File::open(zipfile)?;
     let dir = dir.unwrap_or_else(|| Path::new("."));
-    let reader = zipfile.read_zip()?;
+    let archive = zipfile.read_zip()?;
 
     let mut stats = Stats::default();
-    let total_uncompressed_size = reader
+    let total_uncompressed_size = archive
         .entries()
         .map(|entry| entry.uncompressed_size)
         .sum::<u64>();
@@ -212,10 +208,10 @@ fn unzip(
     };
 
     let start_time = Instant::now();
-    for entry in reader.entries() {
+    for entry in archive.entries() {
         extract_entry(
             entry.to_owned(),
-            &mut entry.reader(),
+            &mut zipfile.reader_at(entry),
             dir,
             &pbar,
             &mut stats,

--- a/rc-zip-cli/src/test.rs
+++ b/rc-zip-cli/src/test.rs
@@ -135,7 +135,7 @@ fn list() {
         let zip_file = fs::File::open(&zip_path).unwrap();
         let archive = zip_file.read_zip().unwrap();
         let mut output = Vec::new();
-        crate::list(&mut output, &archive, verbose).unwrap();
+        crate::list(&mut output, &zip_file, &archive, verbose).unwrap();
         String::from_utf8(output).unwrap()
     }
 

--- a/rc-zip-sync/examples/byte_count.rs
+++ b/rc-zip-sync/examples/byte_count.rs
@@ -1,6 +1,12 @@
 use std::{ffi::OsString, fmt, fs::File, io::Read, sync::Mutex, thread, time};
 
-use rc_zip_sync::{ArchiveHandle, EntryHandle, ReadZip};
+use rc_zip::{Archive, Entry};
+use rc_zip_sync::{HasCursor, ReadZip};
+
+struct EntryHandle<'e, F> {
+    entr: &'e Entry,
+    f: &'e F,
+}
 
 /// Display counts for each byte in a zip's entries
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -9,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let archive = zip_file.read_zip()?;
 
     let start = time::Instant::now();
-    let counts = byte_count_multi_threaded(&archive);
+    let counts = byte_count_multi_threaded(&zip_file, &archive);
     print_stats(counts, start.elapsed());
 
     Ok(())
@@ -60,9 +66,9 @@ impl Counts {
 /// The work is split across a pool of worker threads where each worker takes turns fetching an
 /// entry from the archive to then read over the entry and reduce it down to counts. Then the final
 /// counts are totaled together as each worker finishes.
-fn byte_count_multi_threaded(archive: &ArchiveHandle<'_, File>) -> Counts {
+fn byte_count_multi_threaded(file: &File, archive: &Archive) -> Counts {
     let mut total_counts = Counts::new();
-    let entries = Mutex::new(archive.entries());
+    let entries = Mutex::new(archive.entries().map(|entr| EntryHandle { f: file, entr }));
     let num_workers = thread::available_parallelism().unwrap();
     thread::scope(|s| {
         let worker_handles: Vec<_> = (1..num_workers.into())
@@ -104,9 +110,9 @@ fn byte_count_worker<'zip>(entries: &Mutex<impl Iterator<Item = ZipEntry<'zip>>>
 }
 
 fn entry_add_byte_counts(entry: ZipEntry<'_>, counts: &mut Counts) -> rc_zip::Result<()> {
-    if entry.kind().is_file() {
+    if entry.entr.kind().is_file() {
         let mut buf = [0; 8 * 1024];
-        let mut entry_reader = entry.reader();
+        let mut entry_reader = entry.f.reader_at(entry.entr);
         while let Ok(num_bytes) = entry_reader.read(&mut buf) {
             if num_bytes == 0 {
                 // finished reading!

--- a/rc-zip-sync/examples/self_extracting.rs
+++ b/rc-zip-sync/examples/self_extracting.rs
@@ -8,7 +8,8 @@ use rc_zip::{
     error::{Error, FormatError},
     parse::EntryKind,
 };
-use rc_zip_sync::{ArchiveHandle, ReadZip};
+use rc_zip_sync::rc_zip::Archive;
+use rc_zip_sync::{HasCursor, ReadZip};
 
 /// The executable side of a self-extracting zip file
 ///
@@ -36,12 +37,12 @@ fn main() -> Result<(), Error> {
         }
     })?;
 
-    extract(&archive)?;
+    extract(&zip_file, &archive)?;
 
     Ok(())
 }
 
-fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
+fn extract(file: &File, archive: &Archive) -> Result<(), Error> {
     for entry in archive.entries() {
         println!("extracting {}", entry.name);
         let Some(entry_name) = entry.sanitized_name() else {
@@ -57,7 +58,7 @@ fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
             EntryKind::Directory => fs::create_dir_all(path)?,
             EntryKind::File => {
                 let mut entry_writer = File::create(path)?;
-                let mut entry_reader = entry.reader();
+                let mut entry_reader = file.reader_at(entry);
                 io::copy(&mut entry_reader, &mut entry_writer)?;
             }
             EntryKind::Symlink => {
@@ -66,7 +67,7 @@ fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
                     // creating a symlink on windows is a privileged action, so instead we create a
                     // regular file
                     let mut entry_writer = File::create(path)?;
-                    let mut entry_reader = entry.reader();
+                    let mut entry_reader = file.reader_at(entry);
                     io::copy(&mut entry_reader, &mut entry_writer)?;
                 }
                 #[cfg(unix)]
@@ -81,7 +82,7 @@ fn extract(archive: &ArchiveHandle<'_, File>) -> Result<(), Error> {
                     }
 
                     let mut src = Vec::new();
-                    entry.reader().read_to_end(&mut src)?;
+                    file.reader_at(entry).read_to_end(&mut src)?;
                     let src = OsString::from_vec(src);
 
                     std::os::unix::fs::symlink(&src, path)?;

--- a/rc-zip-sync/src/lib.rs
+++ b/rc-zip-sync/src/lib.rs
@@ -16,6 +16,4 @@ pub use streaming_entry_reader::StreamingEntryReader;
 // re-exports
 pub use entry_reader::EntryReader;
 pub use rc_zip;
-pub use read_zip::{
-    ArchiveHandle, EntryHandle, HasCursor, ReadZip, ReadZipStreaming, ReadZipWithSize,
-};
+pub use read_zip::{HasCursor, ReadZip, ReadZipStreaming, ReadZipWithSize};

--- a/rc-zip-sync/src/read_zip.rs
+++ b/rc-zip-sync/src/read_zip.rs
@@ -207,3 +207,29 @@ where
         }
     }
 }
+
+#[ignore]
+#[test]
+fn t_can_read() {
+    use super::*;
+    use std::fs::File;
+    use std::sync::Arc;
+
+    let f = Arc::new(File::open("").unwrap());
+    f.read_zip().unwrap();
+
+    let f = File::open("").unwrap();
+    f.read_zip().unwrap();
+
+    let f: Vec<u8> = Vec::new();
+    f.read_zip().unwrap();
+
+    let f: &[u8] = &[];
+    f.read_zip().unwrap();
+
+    let f: Box<[u8]> = [].into();
+    (*f).read_zip().unwrap();
+
+    let f: Arc<[u8]> = [].into();
+    (*f).read_zip().unwrap();
+}

--- a/rc-zip-sync/src/read_zip.rs
+++ b/rc-zip-sync/src/read_zip.rs
@@ -195,7 +195,7 @@ where
     }
     /// Returns a reader for the entry.
     pub fn reader(&self) -> EntryReader<<F as HasCursor>::Cursor<'a>> {
-        EntryReader::new(self.entry, self.file.cursor_at(self.entry.header_offset))
+        self.file.reader_at(self.entry)
     }
 
     /// Reads the entire entry into a vector.
@@ -216,6 +216,10 @@ pub trait HasCursor {
 
     /// Returns a [Read] at the given offset.
     fn cursor_at(&self, offset: u64) -> Self::Cursor<'_>;
+    /// Returns a [`EntryReader`] for the given [`Entry`].
+    fn reader_at(&self, entry: &Entry) -> EntryReader<Self::Cursor<'_>> {
+        EntryReader::new(entry, self.cursor_at(entry.header_offset))
+    }
 }
 
 impl HasCursor for &[u8] {

--- a/rc-zip-sync/src/read_zip.rs
+++ b/rc-zip-sync/src/read_zip.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use rc_zip::{
     fsm::{ArchiveFsm, EntryFsm, FsmResult},
     Archive, Entry, Error,
@@ -6,17 +8,13 @@ use tracing::trace;
 
 use crate::entry_reader::EntryReader;
 use crate::streaming_entry_reader::StreamingEntryReader;
-use std::{io::Read, ops::Deref};
 
 /// A trait for reading something as a zip archive
 ///
 /// See also [ReadZip].
 pub trait ReadZipWithSize {
-    /// The type of the file to read from.
-    type File: HasCursor;
-
     /// Reads self as a zip archive.
-    fn read_zip_with_size(&self, size: u64) -> Result<ArchiveHandle<'_, Self::File>, Error>;
+    fn read_zip_with_size(&self, size: u64) -> Result<Archive, Error>;
 }
 
 /// A trait for reading something as a zip archive when we can tell size from
@@ -24,11 +22,8 @@ pub trait ReadZipWithSize {
 ///
 /// See also [ReadZipWithSize].
 pub trait ReadZip {
-    /// The type of the file to read from.
-    type File: HasCursor;
-
     /// Reads self as a zip archive.
-    fn read_zip(&self) -> Result<ArchiveHandle<'_, Self::File>, Error>;
+    fn read_zip(&self) -> Result<Archive, Error>;
 }
 
 struct CursorState<'a, F: HasCursor + 'a> {
@@ -54,9 +49,7 @@ impl<F> ReadZipWithSize for F
 where
     F: HasCursor,
 {
-    type File = F;
-
-    fn read_zip_with_size(&self, size: u64) -> Result<ArchiveHandle<'_, F>, Error> {
+    fn read_zip_with_size(&self, size: u64) -> Result<Archive, Error> {
         let mut cstate: Option<CursorState<'_, F>> = None;
 
         let mut fsm = ArchiveFsm::new(size);
@@ -95,10 +88,7 @@ where
             fsm = match fsm.process()? {
                 FsmResult::Done(archive) => {
                     trace!("read_zip_with_size: done");
-                    return Ok(ArchiveHandle {
-                        file: self,
-                        archive,
-                    });
+                    return Ok(archive);
                 }
                 FsmResult::Continue(fsm) => fsm,
             }
@@ -106,104 +96,9 @@ where
     }
 }
 
-impl ReadZip for &[u8] {
-    type File = Self;
-
-    fn read_zip(&self) -> Result<ArchiveHandle<'_, Self::File>, Error> {
+impl ReadZip for [u8] {
+    fn read_zip(&self) -> Result<Archive, Error> {
         self.read_zip_with_size(self.len() as u64)
-    }
-}
-
-impl ReadZip for Vec<u8> {
-    type File = Self;
-
-    fn read_zip(&self) -> Result<ArchiveHandle<'_, Self::File>, Error> {
-        self.read_zip_with_size(self.len() as u64)
-    }
-}
-
-/// A zip archive, read synchronously from a file or other I/O resource.
-///
-/// This only contains metadata for the archive and its entries. Separate
-/// readers can be created for arbitraries entries on-demand using
-/// [EntryHandle::reader].
-pub struct ArchiveHandle<'a, F>
-where
-    F: HasCursor,
-{
-    file: &'a F,
-    archive: Archive,
-}
-
-impl<F> Deref for ArchiveHandle<'_, F>
-where
-    F: HasCursor,
-{
-    type Target = Archive;
-
-    fn deref(&self) -> &Self::Target {
-        &self.archive
-    }
-}
-
-impl<F> ArchiveHandle<'_, F>
-where
-    F: HasCursor,
-{
-    /// Iterate over all files in this zip, read from the central directory.
-    pub fn entries(&self) -> impl Iterator<Item = EntryHandle<'_, F>> {
-        self.archive.entries().map(move |entry| EntryHandle {
-            file: self.file,
-            entry,
-        })
-    }
-
-    /// Attempts to look up an entry by name. This is usually a bad idea,
-    /// as names aren't necessarily normalized in zip archives.
-    pub fn by_name<N: AsRef<str>>(&self, name: N) -> Option<EntryHandle<'_, F>> {
-        self.archive
-            .entries()
-            .find(|&x| x.name == name.as_ref())
-            .map(|entry| EntryHandle {
-                file: self.file,
-                entry,
-            })
-    }
-}
-
-/// A zip entry, read synchronously from a file or other I/O resource.
-pub struct EntryHandle<'a, F> {
-    file: &'a F,
-    entry: &'a Entry,
-}
-
-impl<F> Deref for EntryHandle<'_, F> {
-    type Target = Entry;
-
-    fn deref(&self) -> &Self::Target {
-        self.entry
-    }
-}
-
-impl<'a, F> EntryHandle<'a, F>
-where
-    F: HasCursor,
-{
-    /// Get the underlying `Entry`
-    pub fn entry(&self) -> &'a Entry {
-        self.entry
-    }
-    /// Returns a reader for the entry.
-    pub fn reader(&self) -> EntryReader<<F as HasCursor>::Cursor<'a>> {
-        self.file.reader_at(self.entry)
-    }
-
-    /// Reads the entire entry into a vector.
-    pub fn bytes(&self) -> std::io::Result<Vec<u8>> {
-        let size = self.uncompressed_size.try_into().unwrap_or(0);
-        let mut v = Vec::with_capacity(size);
-        self.reader().read_to_end(&mut v)?;
-        Ok(v)
     }
 }
 
@@ -219,6 +114,13 @@ pub trait HasCursor {
     /// Returns a [`EntryReader`] for the given [`Entry`].
     fn reader_at(&self, entry: &Entry) -> EntryReader<Self::Cursor<'_>> {
         EntryReader::new(entry, self.cursor_at(entry.header_offset))
+    }
+    /// Reads the entire entry into a vector.
+    fn bytes_at(&self, entr: &Entry) -> std::io::Result<Vec<u8>> {
+        let size = entr.uncompressed_size.try_into().unwrap_or(0);
+        let mut v = Vec::with_capacity(size);
+        self.reader_at(entr).read_to_end(&mut v)?;
+        Ok(v)
     }
 }
 
@@ -258,9 +160,7 @@ impl HasCursor for std::fs::File {
 
 #[cfg(feature = "file")]
 impl ReadZip for std::fs::File {
-    type File = Self;
-
-    fn read_zip(&self) -> Result<ArchiveHandle<'_, Self>, Error> {
+    fn read_zip(&self) -> Result<Archive, Error> {
         let size = self.metadata()?.len();
         self.read_zip_with_size(size)
     }

--- a/rc-zip-sync/tests/integration_tests.rs
+++ b/rc-zip-sync/tests/integration_tests.rs
@@ -1,13 +1,13 @@
 use rc_zip::{Archive, Error};
 use rc_zip_corpus::{zips_dir, Case, Files};
-use rc_zip_sync::{ArchiveHandle, HasCursor, ReadZip, ReadZipStreaming, ReadZipWithSize};
+use rc_zip_sync::{HasCursor, ReadZip, ReadZipStreaming, ReadZipWithSize};
 
 use std::{
     fs::File,
     io::{self, Read},
 };
 
-fn check_case<F: HasCursor>(test: &Case, archive: Result<ArchiveHandle<'_, F>, Error>) {
+fn check_case<F: HasCursor>(test: &Case, f: &F, archive: Result<Archive, Error>) {
     rc_zip_corpus::check_case(test, archive.as_ref().map(|ar| -> &Archive { ar }));
     let archive = match archive {
         Ok(archive) => archive,
@@ -22,7 +22,7 @@ fn check_case<F: HasCursor>(test: &Case, archive: Result<ArchiveHandle<'_, F>, E
                 .unwrap_or_else(|| panic!("entry {} should exist", file.name));
 
             tracing::info!("got entry for {}", file.name);
-            rc_zip_corpus::check_file_against(file, &entry, &entry.bytes().unwrap()[..])
+            rc_zip_corpus::check_file_against(file, entry, &f.bytes_at(entry).unwrap()[..])
         }
     }
 }
@@ -40,7 +40,7 @@ fn read_from_slice() {
     fn consume_file_names<'a>(file_names: impl Iterator<Item = &'a String>) {
         assert_eq!(file_names.count(), 2);
     }
-    consume_file_names(archive.entries().map(|entr| &entr.entry().name));
+    consume_file_names(archive.entries().map(|entr| &entr.name));
 }
 
 #[test]
@@ -64,11 +64,11 @@ fn real_world_files() {
         if let Ok("1") = std::env::var("ONE_BYTE_READ").as_deref() {
             let size = file.metadata().unwrap().len();
             let file = OneByteReadWrapper(file);
-            let archive = file.read_zip_with_size(size);
-            check_case(&case, archive);
+            let archive = file.read_zip_with_size(size).map_err(Error::from);
+            check_case(&case, &file, archive);
         } else {
-            let archive = file.read_zip();
-            check_case(&case, archive);
+            let archive = file.read_zip().map_err(Error::from);
+            check_case(&case, &file, archive);
         };
         drop(guarded_path)
     }
@@ -86,7 +86,7 @@ fn streaming() {
         let mut entry = match file.stream_zip_entries_throwing_caution_to_the_wind() {
             Ok(entry) => entry,
             Err(err) => {
-                check_case::<&[u8]>(&case, Err(err));
+                check_case(&case, &[].as_slice(), Err(err));
                 return;
             }
         };


### PR DESCRIPTION
Not sure if this fact is known, but if we lean further into the concrete entry reader of #162 we get a much less generic API. 

I think this makes the API simpler and more orthogonal with other features of Rust because the reader can still be attached with common iterator methods:

The old API for iterating over entries for example can be expressed as
```rust
let archive = reader.read_zip().unwrap();
archive.entries().map(|entr| reader.reader_at(entr)); // borrowing
// OR
archive.into_entries().map(move |entr| reader.reader_at(entr)); // can be 'static, using PR #158
```

The only downsides I can think of is that in the common case, for example reading from `File` there is a chance that a user misconstrues the reader on another `File`, as it's not passed down internally. Such a mistake would appear to be reasonably easy to find.

Feel free to close if not interested.

Would be an alternative to #157