### PR TITLE
chore: update to rust 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.95.0"
 components = ["llvm-tools", "clippy", "rust-src"]


### PR DESCRIPTION
just bumps the toolchain. `clippy` still seems to be happy (might still be on a feature freeze. i can't remember)