### PR TITLE
ci: freshen up pinned versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-2022, macos-15]
+        os: [windows-2025-vs2026, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Install just, nextest, cargo-llvm-cov, cargo-hack, and wasmtime
         uses: taiki-e/install-action@v2
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Run tests and collect coverage
         run: just ci-test
       - name: Upload coverage information
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -64,7 +64,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:

--- a/Justfile
+++ b/Justfile
@@ -16,7 +16,7 @@ test *args:
 # Run all tests with nextest and cargo-llvm-cov
 ci-test:
     #!/bin/bash -eux
-    export RUSTUP_TOOLCHAIN=nightly
+    export RUSTUP_TOOLCHAIN=nightly-2026-05-10
     rustup target add wasm32-unknown-unknown
     cargo test --no-run -p rc-zip-corpus --all-features --target wasm32-unknown-unknown
     wasmtime target/wasm32-unknown-unknown/debug/deps/integration_tests-*.wasm


### PR DESCRIPTION
b4b70d60115fc7be525e08de5a808e5037b3724f should help with keeping CI fast even when nightly updates, although it is one more version to bump manually :S