### PR TITLE
docs: have a badge per license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![MIT OR Apache-2.0 licensed](https://img.shields.io/badge/license-MIT+Apache_2.0-blue.svg)](./LICENSE)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE-MIT)
+[![Apache-2.0 licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](./LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/rc-zip)](https://crates.io/crates/rc-zip)
 [![docs.rs](https://docs.rs/rc-zip/badge.svg)](https://docs.rs/rc-zip)
 [![codecov](https://codecov.io/gh/bearcove/rc-zip/branch/main/graph/badge.svg)](https://app.codecov.io/gh/bearcove/rc-zip)

--- a/rc-zip-cli/README.md
+++ b/rc-zip-cli/README.md
@@ -1,4 +1,5 @@
-[![MIT OR Apache-2.0 licensed](https://img.shields.io/badge/license-MIT+Apache_2.0-blue.svg)](./LICENSE)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE-MIT)
+[![Apache-2.0 licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](../LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/rc-zip-cli)](https://crates.io/crates/rc-zip-cli)
 [![docs.rs](https://docs.rs/rc-zip-cli/badge.svg)](https://docs.rs/rc-zip-cli)
 

--- a/rc-zip-corpus/README.md
+++ b/rc-zip-corpus/README.md
@@ -1,4 +1,5 @@
-[![MIT OR Apache-2.0 licensed](https://img.shields.io/badge/license-MIT+Apache_2.0-blue.svg)](./LICENSE)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE-MIT)
+[![Apache-2.0 licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](../LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/rc-zip-corpus)](https://crates.io/crates/rc-zip-corpus)
 [![docs.rs](https://docs.rs/rc-zip-corpus/badge.svg)](https://docs.rs/rc-zip-corpus)
 

--- a/rc-zip-sync/README.md
+++ b/rc-zip-sync/README.md
@@ -1,4 +1,5 @@
-[![MIT OR Apache-2.0 licensed](https://img.shields.io/badge/license-MIT+Apache_2.0-blue.svg)](./LICENSE)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE-MIT)
+[![Apache-2.0 licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](../LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/rc-zip-sync)](https://crates.io/crates/rc-zip-sync)
 [![docs.rs](https://docs.rs/rc-zip-sync/badge.svg)](https://docs.rs/rc-zip-sync)
 

--- a/rc-zip-tokio/README.md
+++ b/rc-zip-tokio/README.md
@@ -1,4 +1,5 @@
-[![MIT OR Apache-2.0 licensed](https://img.shields.io/badge/license-MIT+Apache_2.0-blue.svg)](./LICENSE)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE-MIT)
+[![Apache-2.0 licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](../LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/rc-zip-tokio)](https://crates.io/crates/rc-zip-tokio)
 [![docs.rs](https://docs.rs/rc-zip-tokio/badge.svg)](https://docs.rs/rc-zip-tokio)
 

--- a/rc-zip/README.md
+++ b/rc-zip/README.md
@@ -1,4 +1,5 @@
-[![MIT OR Apache-2.0 licensed](https://img.shields.io/badge/license-MIT+Apache_2.0-blue.svg)](./LICENSE)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE-MIT)
+[![Apache-2.0 licensed](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](../LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/rc-zip)](https://crates.io/crates/rc-zip)
 [![docs.rs](https://docs.rs/rc-zip/badge.svg)](https://docs.rs/rc-zip)
 


### PR DESCRIPTION
i noticed that this badge was a bad link since it's pointing to a non-existent `LICENSE` file, so i switched it to two badges -- one per license file

alternatively we could have some sort of `COPYING` file that states the dual licensed nature and point to that